### PR TITLE
카테고리 및 연관관계 추가 및 삭제제외 모든 메소드 구현

### DIFF
--- a/src/main/java/com/example/demo/controller/FoodController.java
+++ b/src/main/java/com/example/demo/controller/FoodController.java
@@ -7,21 +7,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Controller
 @RequestMapping("/food")
 public class FoodController {
 
     private final FoodService foodService;
 
-    @Autowired //생성자 사용해서 DI
     public FoodController(FoodService foodService) {
         this.foodService = foodService;
     }
 
-    //음식 조회
+    //음식 전체 조회
     @GetMapping("/foods")
-    public Food findAll() {
-        return new Food();
+    public List<Food> findAll() {
+        return foodService.findAll();
     }
 
     //음식 등록
@@ -40,5 +41,10 @@ public class FoodController {
     @DeleteMapping("/{foodId}")
     public void delete(String foodId) {
 
+    }
+
+    //특정 음식 조회
+    public Food find(String foodId) {
+        return foodService.find(foodId);
     }
 }

--- a/src/main/java/com/example/demo/domain/Category.java
+++ b/src/main/java/com/example/demo/domain/Category.java
@@ -1,0 +1,19 @@
+package com.example.demo.domain;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Category {
+
+    @Id @GeneratedValue
+    @Column(name = "category_id")
+    private Long id;
+
+    @Column(name = "category_name")
+    private String name;
+
+    @OneToMany(mappedBy = "category")
+    private List<Food> foods  = new ArrayList<>();
+}

--- a/src/main/java/com/example/demo/domain/Food.java
+++ b/src/main/java/com/example/demo/domain/Food.java
@@ -5,10 +5,7 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
 import java.math.BigDecimal;
 
 @Entity
@@ -28,8 +25,18 @@ public class Food {
     @Column(name = "food_price")
     private BigDecimal price; //가격
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
     @Builder
     public Food(String name, Long quantity, BigDecimal price) {
+        this.name = name;
+        this.quantity = quantity;
+        this.price = price;
+    }
+
+    public void updateFood(String name , Long quantity, BigDecimal price) {
         this.name = name;
         this.quantity = quantity;
         this.price = price;

--- a/src/main/java/com/example/demo/repository/FoodRepository.java
+++ b/src/main/java/com/example/demo/repository/FoodRepository.java
@@ -5,13 +5,11 @@ import com.example.demo.domain.FoodDto;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
+import java.util.List;
 
 
 @Repository
-
 public class FoodRepository {
-
-
 
     private final EntityManager em;
 
@@ -19,14 +17,23 @@ public class FoodRepository {
         this.em = em;
     }
 
-    public Food findAll() {
-        return  new Food();
+    public List<Food> findAll() {
+        return  em.createQuery("select f form f", Food.class)
+                .getResultList();
     }
 
     public void save(FoodDto foodDto) {
 
         //여기서 fooddto -> food로 변경해야...
         em.persist(foodDto.toEntity());
+    }
+
+    public Food find(String foodId) {
+        return em.find(Food.class, foodId);
+    }
+    public void edit(String foodId, FoodDto foodDto) {
+        Food food = find(foodId);
+        food.updateFood(foodDto.getName(), foodDto.getQuantity(), foodDto.getPrice()); //영속성에 의해 em 처리없이 자동 update문 생성
     }
 
 }

--- a/src/main/java/com/example/demo/service/FoodService.java
+++ b/src/main/java/com/example/demo/service/FoodService.java
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @Transactional(readOnly = true)
 
@@ -20,8 +22,12 @@ public class FoodService {
     }
 
 
-    public Food findAll() {
+    public List<Food> findAll() {
         return foodRepository.findAll();
+    }
+
+    public Food find(String foodId) {
+        return foodRepository.find(foodId);
     }
 
     //dto를 위한 저장구현

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.datasource.password=root
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDBDialect
 
 spring.jpa.hibernate.ddl-auto=create
+spring.jpa.properties.hibernate.show_sql=true
 
 
 


### PR DESCRIPTION
카테고리와 음식 1:N으로 ERD수정하여 연관관계 생성
update시 EntityManager의 따로 호출없이  find로 food로 가져올경우 영속성 컨텍스트가 관리를 하므로 데이터변경시 dirty 체킹 발생하여 자동 update문생성
하지만 Food 엔티티에 updateFood를 사용하여 데이터를 변경하는 것이 맞는지는 ....더 고민을 해봐야할거같습니다..
다른방법힌트 부탁드립니다...